### PR TITLE
two small fixes

### DIFF
--- a/src/Selector.ts
+++ b/src/Selector.ts
@@ -324,7 +324,7 @@ export class SelectorMode implements Selector {
 		return sheet.suffixFirstSegments("."+this.className);
 	}
 	toString(): string {
-		return "mode-"+this.className+":";
+		return this.className+":";
 	}
 }
 

--- a/src/utils/ValueColor.ts
+++ b/src/utils/ValueColor.ts
@@ -215,6 +215,7 @@ export class ValueColorTransparent {
 
 export type ValueColor =
 	| ValueColorRGB
+	| ValueColorHex
 	| ValueColorHSL
 	| ValueColorCurrent
 	| ValueColorTransparent


### PR DESCRIPTION
The "mode-" prefix is unnecessary in SelectorMode.toString. The classname already contains it.

I forgot to include the new ValueColorHex class in the ValueColor union type, and I did it now.